### PR TITLE
Send generate scripts output to proper folder

### DIFF
--- a/scripts/generate_java.sh
+++ b/scripts/generate_java.sh
@@ -20,7 +20,7 @@ rm -rf "$rootDir/build/java/$ARTIFACT_NAME"
 PYTHONPATH=".:${PYTHONPATH}" python3 "catbuffer/main.py" \
   --schema catbuffer/schemas/all.cats \
   --include catbuffer/schemas \
-  --output "catbuffer/_generated" \
+  --output "catbuffer/_generated/java" \
   --generator java \
   --copyright catbuffer/HEADER.inc
 

--- a/scripts/generate_python.sh
+++ b/scripts/generate_python.sh
@@ -76,7 +76,7 @@ rm -rf "${artifactBuildDir}"
 PYTHONPATH=".:${PYTHONPATH}" python3 "catbuffer/main.py" \
   --schema catbuffer/schemas/all.cats \
   --include catbuffer/schemas \
-  --output "catbuffer/_generated" \
+  --output "catbuffer/_generated/python" \
   --generator python \
   --copyright catbuffer/HEADER.inc
 

--- a/scripts/generate_typescript.sh
+++ b/scripts/generate_typescript.sh
@@ -20,7 +20,7 @@ rm -rf "$rootDir/build/typescript/$ARTIFACT_NAME"
 PYTHONPATH=".:${PYTHONPATH}" python3 "catbuffer/main.py" \
   --schema catbuffer/schemas/all.cats \
   --include catbuffer/schemas \
-  --output "catbuffer/_generated" \
+  --output "catbuffer/_generated/typescript" \
   --generator typescript \
   --copyright catbuffer/HEADER.inc
 


### PR DESCRIPTION
Recently the ${GENERATOR} part of the output folder was dropped
from the main.py generator script in catbuffer, so these
scripts stopped working.
This commit writes the generated code to the proper place so it
is found later when building the artifacts.