### PR TITLE
split TransactionBuilderFactory, to break import dependency loop

### DIFF
--- a/generators/python/PythonFileGenerator.py
+++ b/generators/python/PythonFileGenerator.py
@@ -35,7 +35,7 @@ class PythonFileGenerator(FileGenerator):
         return '../python/templates/'
 
     def get_static_templates_file_names(self):
-        return ['GeneratorUtils', 'AggregateTransactionBodyBuilder', 'TransactionBuilderFactory']
+        return ['GeneratorUtils', 'AggregateTransactionBodyBuilder', 'EmbeddedTransactionBuilderFactory', 'TransactionBuilderFactory']
 
     def get_main_file_extension(self):
         return '.py'

--- a/generators/python/templates/AggregateTransactionBodyBuilder.mako
+++ b/generators/python/templates/AggregateTransactionBodyBuilder.mako
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from functools import reduce
 from typing import List
-import TransactionBuilderFactory
+from .EmbeddedTransactionBuilderFactory import EmbeddedTransactionBuilderFactory
 from .CosignatureBuilder import CosignatureBuilder
 from .EmbeddedTransactionBuilder import EmbeddedTransactionBuilder
 from .GeneratorUtils import GeneratorUtils
@@ -68,7 +68,7 @@ class AggregateTransactionBodyBuilder:
         transactionsByteSize = payloadSize
         transactions: List[EmbeddedTransactionBuilder] = []
         while transactionsByteSize > 0:
-            builder = TransactionBuilderFactory.TransactionBuilderFactory.createEmbeddedTransactionBuilder(bytes_)
+            builder = EmbeddedTransactionBuilderFactory.createBuilder(bytes_)
             transactions.append(builder)
             builderSize = builder.getSize() + GeneratorUtils.getTransactionPaddingSize(builder.getSize(), 8)
             transactionsByteSize -= builderSize

--- a/generators/python/templates/Class.mako
+++ b/generators/python/templates/Class.mako
@@ -92,7 +92,7 @@ class ${generator.generated_class_name}${'(' + str(generator.generated_base_clas
         ${a.attribute_name}ByteSize = ${a.attribute_size}  # kind:VAR_ARRAY
         ${a.attribute_name}: List[${a.attribute_class_name}] = []
         while ${a.attribute_name}ByteSize > 0:
-            item = TransactionBuilderFactory.createEmbeddedTransactionBuilder(bytes_)
+            item = EmbeddedTransactionBuilderFactory.createBuilder(bytes_)
             transactions.append(item)
             itemSize = item.getSize() + GeneratorUtils.getTransactionPaddingSize(item.getSize(), 8)
             ${a.attribute_name}ByteSize -= itemSize

--- a/generators/python/templates/EmbeddedTransactionBuilderFactory.mako
+++ b/generators/python/templates/EmbeddedTransactionBuilderFactory.mako
@@ -1,32 +1,31 @@
 # pylint: disable=R0911,R0912
 
-# Imports for creating transaction builders
-from .TransactionBuilder import TransactionBuilder
+# Imports for creating embedded transaction builders
+from .EmbeddedTransactionBuilder import EmbeddedTransactionBuilder
 % for name in sorted(generator.schema):
 <%
     layout = generator.schema[name].get("layout", [{type:""}])
     entityTypeValue = next(iter([x for x in layout if x.get('name','') == 'entityType']),{}).get('value',0)
 %>\
-% if entityTypeValue > 0 and 'Block' not in name:
-from .${name}Builder import ${name}Builder
+% if entityTypeValue > 0 and 'Aggregate' not in name and 'Block' not in name:
+from .Embedded${name}Builder import Embedded${name}Builder
 % endif
 % endfor
 
-
-class TransactionBuilderFactory:
-    """Factory in charge of creating the specific transaction builder from the binary payload.
+class EmbeddedTransactionBuilderFactory:
+    """Factory in charge of creating the specific embedded transaction builder from the binary payload.
     """
 
     @classmethod
-    def createBuilder(cls, payload) -> TransactionBuilder:
+    def createBuilder(cls, payload) -> EmbeddedTransactionBuilder:
         """
-        It creates the specific transaction builder from the payload bytes.
+        It creates the specific embedded transaction builder from the payload bytes.
         Args:
             payload: bytes
         Returns:
-            the TransactionBuilder subclass
+            the EmbeddedTransactionBuilder subclass
         """
-        headerBuilder = TransactionBuilder.loadFromBinary(payload)
+        headerBuilder = EmbeddedTransactionBuilder.loadFromBinary(payload)
         entityType = headerBuilder.getType().value
         entityTypeVersion = headerBuilder.getVersion()
 % for name in generator.schema:
@@ -35,9 +34,9 @@ class TransactionBuilderFactory:
     entityTypeValue = next(iter([x for x in layout if x.get('name','') == 'entityType']),{}).get('value',0)
     entityTypeVersion = next(iter([x for x in layout if x.get('name','') == 'version']),{}).get('value',0)
 %>\
-    % if entityTypeValue > 0 and 'Block' not in name:
+% if entityTypeValue > 0 and 'Aggregate' not in name and 'Block' not in name:
         if entityType == ${entityTypeValue} and entityTypeVersion == ${entityTypeVersion}:
-            return ${name}Builder.loadFromBinary(payload)
-    % endif
+            return Embedded${name}Builder.loadFromBinary(payload)
+% endif
 % endfor
         return headerBuilder


### PR DESCRIPTION
there's currently dependency loop:
 1. `TransactionBuilderFactory` imports `AggregateBondedTransactionBuilder` and `AggregateCompleteTransactionBuilder`
 2. both of them import `AggregateTransactionBodyBuilder`
 3. `AggregateTransactionBodyBuilder` has `import TransactionBuilderFactory`
 
 it works when you import TransactionBuilderFactory, but there's no way to import either AggregateBondedTransactionBuilder or AggregateCompleteTransactionBuilder.
 
 I've broken dependency loop by extracting EmbeddedTransactionBuilderFactory from TransactionBuilderFactory.
 I also renamed factory method to createBuilder, as it should be obvious from the factory used:
 ```
 EmbeddedTransactionBuilderFactory.createBuilder
 TransactionBuilderFactory.createBuilder
 ```